### PR TITLE
Create first webpage and Jekyll directory

### DIFF
--- a/_data/menus.csv
+++ b/_data/menus.csv
@@ -1,0 +1,5 @@
+name,url
+Home,/
+Blog,/blog/
+Projects,/projects/
+About,/about/

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,3 @@
+    <footer>
+      <div>This site was built using <a href="http://jekyllrb.com/">Jekyll<a/>.</div>
+    </footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,8 @@
+    <header>
+      <div>silverferret4</div>
+      <nav>
+        <ul>
+          {% for menu in site.data.menus %}<li><a href="{{ menu.url }}">{{ menu.name }}</a></li>
+        {% endfor %}</ul>
+      </nav>
+    </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+	  <!-- CSS -->
+	  <link rel="stylesheet" href="/css/master.css" type="text/css" />
+  </head>
+  <body>
+    <!-- Contains <header> tag -->
+    {% include header.html %}
+    <!-- Content wrapped in div with id="content" -->
+    {{ content }}
+    <!-- Contains <footer> tag -->
+    {% include footer.html %}
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,3 +1,3 @@
-<h1>
-Hello World
-</h1>
+<div id="content">
+  Simple blurb of text here to show that the content area is getting loaded correctly.
+</div>


### PR DESCRIPTION
Addresses several issues, including:
- #2: Basic HTML homepage.
- Not including styling, this is just the basic HTML.
- #10: Added Default Jekyll template.
- **default.html** added to the **_layouts/** directory.
- #18: Create nav menu dynamically
- Using the **_data/** directory and a **CSV** file to populate the
  creation of the menus.  The code itself is contained in the
  **header.html** file and is a simple loop that creates an Unordered
  List.
- #19: Fixed HTML Issues.
- So I was not fully understanding how Jekyll bundles everything, and
  I thought that each of the fragments that have an **.html** extension
  should be a complete document.  Not the case at all actually, and now I
  am correctly building them as reusable fragments that will ultimately
  be pieced together to create one complete and valid HTML.
